### PR TITLE
Dont store the currency object on the money, store the currency code

### DIFF
--- a/lib/money.js
+++ b/lib/money.js
@@ -10,41 +10,43 @@
 /**
  * Creates a new Money instance.
  * The created Money instances is a value object thus it is immutable.
- * 
+ *
  * @param {Number} amount
- * @param {Object} currency
+ * @param {Object/String} currency object or currency code
  * @returns {Money}
  * @constructor
  */
-function Money(amount, currency) {
+Money = function (amount, currencyCodeOrObject) {
     var multipliers = [0, 10, 100, 1000];
-    
-    if (typeof currency !== 'object')
-        throw new TypeError('Invalid currency');
-    
+
     var decimals = decimalPlaces(amount);
 
+    var currencyCode = currencyCodeOrObject.code || currencyCodeOrObject;
+    var currency = Money[currencyCode];
+    if (! currency)
+        throw new TypeError('Unrecognized currency: ' + currencyCodeOrObject);
+
     if (decimals > currency.decimal_digits)
-        throw new Error("The currency " + currency.code + " supports only " 
+        throw new Error("The currency " + currency.code + " supports only "
             + currency.decimal_digits + " decimal digits");
-    
-    this.amount = decimals > 0 ? amount * multipliers[decimals] : amount;    
-    this.currency = currency;
+
+    this.amount = decimals > 0 ? amount * multipliers[decimals] : amount;
+    this.currencyCode = currencyCode;
     Object.freeze(this);
 };
 
 var decimalPlaces = function(num) {
     var match = ('' + num).match(/(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/);
-    
-    if (!match) 
+
+    if (!match)
         return 0;
-    
-    return Math.max(0, 
+
+    return Math.max(0,
         (match[1] ? match[1].length : 0) - (match[2] ? +match[2] : 0));
 };
 
 var assertSameCurrency = function(left, right) {
-    if (left.currency !== right.currency)
+    if (left.currencyCode !== right.currencyCode)
         throw new Error('Different currencies');
 };
 
@@ -58,9 +60,10 @@ var assertOperand = function(operand) {
         throw new TypeError('Operand must be a number');
 };
 
+
 /**
  * Returns true if the two instances of Money are equal, false otherwise.
- * 
+ *
  * @param {Money} other
  * @returns {Boolean}
  */
@@ -69,12 +72,12 @@ Money.prototype.equals = function(other) {
     assertType(other);
 
     return self.amount === other.amount &&
-            self.currency === other.currency;
+            self.currencyCode === other.currencyCode;
 };
 
 /**
  * Adds the two objects together creating a new Money instance that holds the result of the operation.
- * 
+ *
  * @param {Money} other
  * @returns {Money}
  */
@@ -83,12 +86,12 @@ Money.prototype.add = function(other) {
     assertType(other);
     assertSameCurrency(self, other);
 
-    return new Money(self.amount + other.amount, self.currency);
+    return new Money(self.amount + other.amount, self.currencyCode);
 };
 
 /**
  * Subtracts the two objects creating a new Money instance that holds the result of the operation.
- * 
+ *
  * @param {Money} other
  * @returns {Money}
  */
@@ -97,12 +100,12 @@ Money.prototype.subtract = function(other) {
     assertType(other);
     assertSameCurrency(self, other);
 
-    return new Money(self.amount - other.amount, self.currency);
+    return new Money(self.amount - other.amount, self.currencyCode);
 };
 
 /**
  * Multiplies the object by the multiplier returning a new Money instance that holds the result of the operation.
- * 
+ *
  * @param {Number} multiplier
  * @returns {Money}
  */
@@ -110,12 +113,12 @@ Money.prototype.multiply = function(multiplier) {
     assertOperand(multiplier);
     var amount = Math.round(this.amount * multiplier);
 
-    return new Money(amount, this.currency);
+    return new Money(amount, this.currencyCode);
 };
 
 /**
  * Divides the object by the multiplier returning a new Money instance that holds the result of the operation.
- * 
+ *
  * @param {Number} divisor
  * @returns {Money}
  */
@@ -123,12 +126,12 @@ Money.prototype.divide = function(divisor) {
     assertOperand(divisor);
     var amount = Math.round(this.amount / divisor);
 
-    return new Money(amount, this.currency);
+    return new Money(amount, this.currencyCode);
 };
 
 /**
  * Allocates fund bases on the ratios provided returing an array of objects as a product of the allocation.
- * 
+ *
  * @param {Array} other
  * @returns {Array.Money}
  */
@@ -144,12 +147,12 @@ Money.prototype.allocate = function(ratios) {
 
     ratios.forEach(function(ratio) {
         var share = Math.floor(self.amount * ratio / total)
-        results.push(new Money(share, self.currency));
+        results.push(new Money(share, self.currencyCode));
         remainder -= share;
     });
 
     for (var i = 0; remainder > 0; i++) {
-        results[i] = new Money(results[i].amount + 1, results[i].currency);
+        results[i] = new Money(results[i].amount + 1, results[i].currencyCode);
         remainder--;
     }
 
@@ -157,8 +160,8 @@ Money.prototype.allocate = function(ratios) {
 };
 
 /**
- * Compares two instances of Money. 
- * 
+ * Compares two instances of Money.
+ *
  * @param {Money} other
  * @returns {Number}
  */


### PR DESCRIPTION
I thought this PR could be more like the start of a conversation.  I haven't done tests or changed the readme, as I wasn't sure your reaction.  

Basically for my usecase I want to store these Money objects in a JSON database (mongo in this case) and I don't want to store the entire currency object.  Also I'm thinking that over time, it'd be better to move to someone's more standard/comprehensive take on currencies as they change more often than you might think.

But that's really a side point, I'm more trying to make them serialize smaller and support the case where you're reading from a datasource that has ISO currency codes, but not references to the object itself.  

BTW, this library is exactly what I was looking for and I super appreciate your work here.

cheers,
andy
