### PR TITLE
When a ratio of 0 is provided, the allocated amount should always be 0

### DIFF
--- a/lib/money.js
+++ b/lib/money.js
@@ -42,16 +42,16 @@ var assertOperand = function (operand) {
 /**
  * Creates a new Money instance.
  * The created Money instances is a value object thus it is immutable.
- * 
+ *
  * @param {Number} amount
  * @param {Object/String} currency
  * @returns {Money}
  * @constructor
  */
 function Money(amount, currency) {
-    if (_.isString(currency)) 
+    if (_.isString(currency))
         currency = currencies[currency];
-   
+
     if (!_.isPlainObject(currency))
         throw new TypeError('Invalid currency');
 
@@ -106,7 +106,7 @@ Money.fromDecimal = function (amount, currency) {
 
 /**
  * Returns true if the two instances of Money are equal, false otherwise.
- * 
+ *
  * @param {Money} other
  * @returns {Boolean}
  */
@@ -120,7 +120,7 @@ Money.prototype.equals = function (other) {
 
 /**
  * Adds the two objects together creating a new Money instance that holds the result of the operation.
- * 
+ *
  * @param {Money} other
  * @returns {Money}
  */
@@ -134,7 +134,7 @@ Money.prototype.add = function (other) {
 
 /**
  * Subtracts the two objects creating a new Money instance that holds the result of the operation.
- * 
+ *
  * @param {Money} other
  * @returns {Money}
  */
@@ -148,7 +148,7 @@ Money.prototype.subtract = function (other) {
 
 /**
  * Multiplies the object by the multiplier returning a new Money instance that holds the result of the operation.
- * 
+ *
  * @param {Number} multiplier
  * @param {Function} [fn=Math.round]
  * @returns {Money}
@@ -165,7 +165,7 @@ Money.prototype.multiply = function (multiplier, fn) {
 
 /**
  * Divides the object by the multiplier returning a new Money instance that holds the result of the operation.
- * 
+ *
  * @param {Number} divisor
  * @param {Function} [fn=Math.round]
  * @returns {Money}
@@ -182,7 +182,7 @@ Money.prototype.divide = function (divisor, fn) {
 
 /**
  * Allocates fund bases on the ratios provided returing an array of objects as a product of the allocation.
- * 
+ *
  * @param {Array} other
  * @returns {Array.Money}
  */
@@ -203,7 +203,9 @@ Money.prototype.allocate = function (ratios) {
     });
 
     for (var i = 0; remainder > 0; i++) {
-        results[i] = new Money(results[i].amount + 1, results[i].currency);
+        var idx = i % results.length;
+        if (results[idx].isZero()) continue;
+        results[idx] = new Money(results[idx].amount + 1, results[idx].currency);
         remainder--;
     }
 
@@ -211,8 +213,8 @@ Money.prototype.allocate = function (ratios) {
 };
 
 /**
- * Compares two instances of Money. 
- * 
+ * Compares two instances of Money.
+ *
  * @param {Money} other
  * @returns {Number}
  */

--- a/test/money.test.js
+++ b/test/money.test.js
@@ -191,6 +191,15 @@ describe('Money', function () {
        expect(results[2].currency).to.equal('EUR');             
     });
 
+    it('should allocate correctly with 0% ratio', function() {
+        var subject = new Money(1001, Money.EUR);
+        var results = subject.allocate([0, .5, .5]);
+
+        expect(results[0].amount).to.equal(0);
+        expect(results[1].amount).to.equal(501);
+        expect(results[2].amount).to.equal(500);
+    });
+
     it('zero check works correctly', function() {
         var subject = new Money(1000, 'EUR');
         var subject1 = new Money(0, 'EUR');


### PR DESCRIPTION
This changes the behavior for adjusting unevenly divided amounts when a ratio is 0.

I think in most use cases, returning anything other than zero for a ratio of zero would be unexpected behavior.