### PR TITLE
[v0.5.1] toJSON serialises the instance

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "js-money",
     "description": "JavaScript implementation of the Money value object.",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "main": "./lib",
     "author": {
         "name": "David Kalosi",

--- a/lib/money.js
+++ b/lib/money.js
@@ -42,16 +42,16 @@ var assertOperand = function (operand) {
 /**
  * Creates a new Money instance.
  * The created Money instances is a value object thus it is immutable.
- * 
+ *
  * @param {Number} amount
  * @param {Object/String} currency
  * @returns {Money}
  * @constructor
  */
 function Money(amount, currency) {
-    if (_.isString(currency)) 
+    if (_.isString(currency))
         currency = currencies[currency];
-   
+
     if (!_.isPlainObject(currency))
         throw new TypeError('Invalid currency');
 
@@ -101,12 +101,13 @@ Money.fromDecimal = function (amount, currency) {
         throw new Error("The currency " + currency.code + " supports only "
             + currency.decimal_digits + " decimal digits");
 
-    return new Money(amount * multipliers[currency.decimal_digits], currency);
+    var integerAmount = amount * multipliers[currency.decimal_digits];
+    return new Money(Math.round(integerAmount), currency);
 };
 
 /**
  * Returns true if the two instances of Money are equal, false otherwise.
- * 
+ *
  * @param {Money} other
  * @returns {Boolean}
  */
@@ -120,7 +121,7 @@ Money.prototype.equals = function (other) {
 
 /**
  * Adds the two objects together creating a new Money instance that holds the result of the operation.
- * 
+ *
  * @param {Money} other
  * @returns {Money}
  */
@@ -134,7 +135,7 @@ Money.prototype.add = function (other) {
 
 /**
  * Subtracts the two objects creating a new Money instance that holds the result of the operation.
- * 
+ *
  * @param {Money} other
  * @returns {Money}
  */
@@ -148,7 +149,7 @@ Money.prototype.subtract = function (other) {
 
 /**
  * Multiplies the object by the multiplier returning a new Money instance that holds the result of the operation.
- * 
+ *
  * @param {Number} multiplier
  * @param {Function} [fn=Math.round]
  * @returns {Money}
@@ -165,7 +166,7 @@ Money.prototype.multiply = function (multiplier, fn) {
 
 /**
  * Divides the object by the multiplier returning a new Money instance that holds the result of the operation.
- * 
+ *
  * @param {Number} divisor
  * @param {Function} [fn=Math.round]
  * @returns {Money}
@@ -182,7 +183,7 @@ Money.prototype.divide = function (divisor, fn) {
 
 /**
  * Allocates fund bases on the ratios provided returing an array of objects as a product of the allocation.
- * 
+ *
  * @param {Array} other
  * @returns {Array.Money}
  */
@@ -211,8 +212,8 @@ Money.prototype.allocate = function (ratios) {
 };
 
 /**
- * Compares two instances of Money. 
- * 
+ * Compares two instances of Money.
+ *
  * @param {Money} other
  * @returns {Number}
  */
@@ -269,9 +270,21 @@ Money.prototype.toDecimal = function () {
  *
  * @returns {string}
  */
-Money.prototype.toJSON = Money.prototype.toString = function () {
+Money.prototype.toString = function () {
     var currency = currencies[this.currency];
     return (this.amount / Math.pow(10, currency.decimal_digits)).toFixed(currency.decimal_digits);
+};
+
+/**
+ * Returns a serialised version of the instance.
+ *
+ * @returns {{amount: number, currency: string}}
+ */
+Money.prototype.toJSON = function () {
+    return {
+        amount: this.amount,
+        currency: this.currency
+    };
 };
 
 module.exports = _.extend(Money, currencies);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "js-money",
     "description": "JavaScript implementation of the Money value object.",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "main": "./lib",
     "author": {
         "name": "David Kalosi",

--- a/test/money.test.js
+++ b/test/money.test.js
@@ -10,13 +10,13 @@
 var Money = require('../lib/index');
 
 describe('Money', function () {
-    it('should create a new instance from integer', function () {        
+    it('should create a new instance from integer', function () {
         var money = new Money(1000, Money.EUR);
 
         expect(money.amount).to.equal(1000);
         expect(money.currency).to.equal('EUR');
     });
-    
+
     it('should not create a new instance from decimal', function () {
         expect(function () {
             new Money(10.42, Money.EUR);
@@ -47,7 +47,7 @@ describe('Money', function () {
             Money.fromDecimal(10.421, Money.EUR);
         }).to.throw(Error);
     });
-    
+
     it('should create a new instance from string currency', function () {
         var money = new Money(1042, 'EUR');
 
@@ -95,18 +95,18 @@ describe('Money', function () {
             new Money(10, 'XYZ')
         }).to.throw(TypeError);
     });
-    
+
     it('should serialize correctly', function() {
         var money = new Money(1042, Money.EUR);
-        
+
         expect(money.amount).to.be.a.number;
         expect(money.currency).to.be.a.string;
     });
-    
-    it('should check for decimal precision', function() {      
+
+    it('should check for decimal precision', function() {
         expect(function() {
             new Money(10.423456, Money.EUR)
-        }).to.throw(Error);        
+        }).to.throw(Error);
     });
 
     it('should add same currencies', function () {
@@ -137,9 +137,9 @@ describe('Money', function () {
 
     it('should check if equal', function () {
         var first = new Money(1000, Money.EUR);
-        var second = new Money(1000, Money.EUR);    
-        var third = new Money(1000, Money.USD);  
-        var fourth = new Money(100, Money.EUR);  
+        var second = new Money(1000, Money.EUR);
+        var third = new Money(1000, Money.USD);
+        var fourth = new Money(100, Money.EUR);
 
         expect(first.equals(second)).to.equal(true);
         expect(first.equals(third)).to.equal(false);
@@ -153,15 +153,15 @@ describe('Money', function () {
         expect(subject.compare(new Money(500, Money.EUR))).to.equal(1);
         expect(subject.compare(new Money(1000, Money.EUR))).to.equal(0);
     });
-    
+
     it('should subtract same currencies correctly', function() {
         var subject = new Money(1000, Money.EUR);
         var result = subject.subtract(new Money(250, Money.EUR));
-        
+
         expect(result.amount).to.equal(750);
         expect(result.currency).to.equal('EUR');
     });
-    
+
     it('should multiply correctly', function() {
         var subject = new Money(1000, Money.EUR);
 
@@ -169,7 +169,7 @@ describe('Money', function () {
         expect(subject.multiply(1.2234, Math.ceil).amount).to.equal(1224);
         expect(subject.multiply(1.2234, Math.floor).amount).to.equal(1223);
     });
-    
+
     it('should divide correctly', function() {
         var subject = new Money(1000, Money.EUR);
 
@@ -177,18 +177,18 @@ describe('Money', function () {
         expect(subject.divide(2.234, Math.ceil).amount).to.equal(448);
         expect(subject.divide(2.234, Math.floor).amount).to.equal(447);
     });
-    
+
     it('should allocate correctly', function() {
        var subject = new Money(1000, Money.EUR);
        var results = subject.allocate([1,1,1]);
-       
+
        expect(results.length).to.equal(3);
        expect(results[0].amount).to.equal(334);
        expect(results[0].currency).to.equal('EUR');
        expect(results[1].amount).to.equal(333);
        expect(results[1].currency).to.equal('EUR');
-       expect(results[2].amount).to.equal(333);    
-       expect(results[2].currency).to.equal('EUR');             
+       expect(results[2].amount).to.equal(333);
+       expect(results[2].currency).to.equal('EUR');
     });
 
     it('zero check works correctly', function() {
@@ -234,6 +234,6 @@ describe('Money', function () {
     it('should allow to be stringified as JSON', function () {
         var subject = new Money(1000, 'EUR');
 
-        expect(JSON.stringify({ foo: subject })).to.equal('{"foo":"10.00"}');
+        expect(JSON.stringify({ foo: subject })).to.equal('{"foo":{"amount":1000,"currency":"EUR"}}');
     });
 });


### PR DESCRIPTION
# Changes
* stringifiing the instance no longer turns it into a decimal as a string (prefer `.toString()` method for that purpose). Avoids loosing the currency.
* Removes some trailing spaces in the edited files (consequence of the `.editorconfig` file from previous #7).