### PR TITLE
Fix decimal digits for the RSD currency

### DIFF
--- a/lib/currency.js
+++ b/lib/currency.js
@@ -831,7 +831,7 @@ var currencies = {
         "symbol": "din.",
         "name": "Serbian Dinar",
         "symbol_native": "дин.",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "RSD",
         "name_plural": "Serbian dinars"


### PR DESCRIPTION
As a developer from Serbia, I can assure you that Serbian dinars use 2 decimal digits for money values :)

Also, not quite sure what the `rounding` property does, but it seems that it isn't really used anywhere in the code, so I left it as-is.