### PR TITLE
Russian Rouble native symbol

### DIFF
--- a/lib/currency.js
+++ b/lib/currency.js
@@ -839,7 +839,7 @@ var currencies = {
     "RUB": {
         "symbol": "RUB",
         "name": "Russian Ruble",
-        "symbol_native": "руб.",
+        "symbol_native": "₽",
         "decimal_digits": 2,
         "rounding": 0,
         "code": "RUB",


### PR DESCRIPTION
Use ₽ as a native symbol for Russian Rouble. It is officially approved by Russian Central Bank and widely used in Russia.