### PR TITLE
upgrade to lodash 4.x, split to separate imports

### DIFF
--- a/lib/money.js
+++ b/lib/money.js
@@ -7,7 +7,12 @@
  * file that was distributed with this source code.
  */
 
-var _ = require('lodash');
+var extend = require('lodash/extend');
+var isFunction = require('lodash/isFunction');
+var isNaN = require('lodash/isNaN');
+var isObject = require('lodash/isObject');
+var isPlainObject = require('lodash/isPlainObject');
+var isString = require('lodash/isString');
 var currencies = require('./currency');
 
 var isInt = function (n) {
@@ -49,10 +54,10 @@ var assertOperand = function (operand) {
  * @constructor
  */
 function Money(amount, currency) {
-    if (_.isString(currency))
+    if (isString(currency))
         currency = currencies[currency];
 
-    if (!_.isPlainObject(currency))
+    if (!isPlainObject(currency))
         throw new TypeError('Invalid currency');
 
     if (!isInt(amount))
@@ -64,7 +69,7 @@ function Money(amount, currency) {
 }
 
 Money.fromInteger = function (amount, currency) {
-    if (_.isObject(amount)) {
+    if (isObject(amount)) {
         if (amount.amount === undefined || amount.currency === undefined)
             throw new TypeError('Missing required parameters amount,currency');
 
@@ -81,7 +86,7 @@ Money.fromInteger = function (amount, currency) {
 Money.fromDecimal = function (amount, currency) {
     var multipliers = [1, 10, 100, 1000];
 
-    if (_.isObject(amount)) {
+    if (isObject(amount)) {
         if (amount.amount === undefined || amount.currency === undefined)
             throw new TypeError('Missing required parameters amount,currency');
 
@@ -89,10 +94,10 @@ Money.fromDecimal = function (amount, currency) {
         amount = amount.amount;
     }
 
-    if (_.isString(currency))
+    if (isString(currency))
         currency = currencies[currency];
 
-    if (!_.isPlainObject(currency))
+    if (!isPlainObject(currency))
         throw new TypeError('Invalid currency');
 
     var decimals = decimalPlaces(amount);
@@ -155,7 +160,7 @@ Money.prototype.subtract = function (other) {
  * @returns {Money}
  */
 Money.prototype.multiply = function (multiplier, fn) {
-    if (!_.isFunction(fn))
+    if (!isFunction(fn))
         fn = Math.round;
 
     assertOperand(multiplier);
@@ -172,7 +177,7 @@ Money.prototype.multiply = function (multiplier, fn) {
  * @returns {Money}
  */
 Money.prototype.divide = function (divisor, fn) {
-    if (!_.isFunction(fn))
+    if (!isFunction(fn))
         fn = Math.round;
 
     assertOperand(divisor);
@@ -287,4 +292,4 @@ Money.prototype.toJSON = function () {
     };
 };
 
-module.exports = _.extend(Money, currencies);
+module.exports = extend(Money, currencies);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com/davidkalosi/js-money/issues"
     },
     "dependencies": {
-        "lodash": "3.x.x"
+        "lodash": "4.x.x"
     },
     "devDependencies": {
         "mocha": "1.x.x",


### PR DESCRIPTION
This will significantly reduce bundle size by not importing the entirety of the `lodash` package.