### PR TITLE
add files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "email": "david.kalosi@gmail.com"
     },
     "keywords": ["money", "javascript", "currency"],
+    "files": ["lib"],
     "licenses": {
         "type": "MIT"
     },


### PR DESCRIPTION
If you look [here](https://unpkg.com/js-money@0.6.0/) you'll notice that there are several files included with this package on the registry that don't need to be. This causes npm installs of this module to result in downloading more than necessary.

By adding this [`files`](https://docs.npmjs.com/files/package.json#files) array to `package.json` you can specifically list the files that are important for people to download for your module. By default, npm will also include `README` and `LICENSE` files as well.