### PR TITLE
Update decimal places according to ISO4217 standard

### DIFF
--- a/lib/currency.js
+++ b/lib/currency.js
@@ -48,7 +48,7 @@ var currencies = {
         "symbol": "Af",
         "name": "Afghan Afghani",
         "symbol_native": "؋",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "AFN",
         "name_plural": "Afghan Afghanis"
@@ -57,7 +57,7 @@ var currencies = {
         "symbol": "ALL",
         "name": "Albanian Lek",
         "symbol_native": "Lek",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "ALL",
         "name_plural": "Albanian lekë"
@@ -66,7 +66,7 @@ var currencies = {
         "symbol": "AMD",
         "name": "Armenian Dram",
         "symbol_native": "դր.",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "AMD",
         "name_plural": "Armenian drams"
@@ -237,7 +237,7 @@ var currencies = {
         "symbol": "CO$",
         "name": "Colombian Peso",
         "symbol_native": "$",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "COP",
         "name_plural": "Colombian pesos"
@@ -246,7 +246,7 @@ var currencies = {
         "symbol": "₡",
         "name": "Costa Rican Colón",
         "symbol_native": "₡",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "CRC",
         "name_plural": "Costa Rican colóns"
@@ -417,7 +417,7 @@ var currencies = {
         "symbol": "Ft",
         "name": "Hungarian Forint",
         "symbol_native": "Ft",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "HUF",
         "name_plural": "Hungarian forints"
@@ -426,7 +426,7 @@ var currencies = {
         "symbol": "Rp",
         "name": "Indonesian Rupiah",
         "symbol_native": "Rp",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "IDR",
         "name_plural": "Indonesian rupiahs"
@@ -453,7 +453,7 @@ var currencies = {
         "symbol": "IQD",
         "name": "Iraqi Dinar",
         "symbol_native": "د.ع.‏",
-        "decimal_digits": 0,
+        "decimal_digits": 3,
         "rounding": 0,
         "code": "IQD",
         "name_plural": "Iraqi dinars"
@@ -462,7 +462,7 @@ var currencies = {
         "symbol": "IRR",
         "name": "Iranian Rial",
         "symbol_native": "﷼",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "IRR",
         "name_plural": "Iranian rials"
@@ -561,7 +561,7 @@ var currencies = {
         "symbol": "₭",
         "name": "Lao kip",
         "symbol_native": "ກີບ",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "LAK",
         "name_plural": "Lao kips"
@@ -570,7 +570,7 @@ var currencies = {
         "symbol": "LB£",
         "name": "Lebanese Pound",
         "symbol_native": "ل.ل.‏",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "LBP",
         "name_plural": "Lebanese pounds"
@@ -633,7 +633,7 @@ var currencies = {
         "symbol": "MGA",
         "name": "Malagasy Ariary",
         "symbol_native": "MGA",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "MGA",
         "name_plural": "Malagasy Ariaries"
@@ -651,7 +651,7 @@ var currencies = {
         "symbol": "MMK",
         "name": "Myanma Kyat",
         "symbol_native": "K",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "MMK",
         "name_plural": "Myanma kyats"
@@ -669,7 +669,7 @@ var currencies = {
         "symbol": "MURs",
         "name": "Mauritian Rupee",
         "symbol_native": "MURs",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "MUR",
         "name_plural": "Mauritian rupees"
@@ -795,7 +795,7 @@ var currencies = {
         "symbol": "PKRs",
         "name": "Pakistani Rupee",
         "symbol_native": "₨",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "PKR",
         "name_plural": "Pakistani rupees"
@@ -903,7 +903,7 @@ var currencies = {
         "symbol": "Ssh",
         "name": "Somali Shilling",
         "symbol_native": "Ssh",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "SOS",
         "name_plural": "Somali shillings"
@@ -912,7 +912,7 @@ var currencies = {
         "symbol": "SY£",
         "name": "Syrian Pound",
         "symbol_native": "ل.س.‏",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "SYP",
         "name_plural": "Syrian pounds"
@@ -975,7 +975,7 @@ var currencies = {
         "symbol": "TSh",
         "name": "Tanzanian Shilling",
         "symbol_native": "TSh",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "TZS",
         "name_plural": "Tanzanian shillings"
@@ -1011,7 +1011,7 @@ var currencies = {
         "symbol": "UZS",
         "name": "Uzbekistan Som",
         "symbol_native": "UZS",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "UZS",
         "name_plural": "Uzbekistan som"
@@ -1056,7 +1056,7 @@ var currencies = {
         "symbol": "YR",
         "name": "Yemeni Rial",
         "symbol_native": "ر.ي.‏",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
         "code": "YER",
         "name_plural": "Yemeni rials"

--- a/test/money.test.js
+++ b/test/money.test.js
@@ -263,4 +263,38 @@ describe('Money', function () {
         expect(subject.getAmount()).to.equal(1000);
         expect(subject.getCurrency()).to.equal('EUR');
     });
+
+    it('should convert from decimal per currency', function () {
+        var euro = Money.fromDecimal(123.45, 'EUR');
+        var forint = Money.fromDecimal(123.45, 'HUF');
+        var yen = Money.fromDecimal(12345, 'JPY');
+        var dinar = Money.fromDecimal(12.345, 'BHD');
+
+        expect(euro.amount).to.equal(12345);
+        expect(forint.amount).to.equal(12345);
+        expect(yen.amount).to.equal(12345);
+        expect(dinar.amount).to.equal(12345);
+    });
+
+    it('should convert to decimal per currency', function () {
+        var euro = new Money(12345, 'EUR');
+        var forint = new Money(12345, 'HUF');
+        var yen = new Money(12345, 'JPY');
+        var dinar = new Money(12345, 'BHD');
+
+        expect(euro.toDecimal()).to.equal(123.45);
+        expect(forint.toDecimal()).to.equal(123.45);
+        expect(yen.toDecimal()).to.equal(12345);
+        expect(dinar.toDecimal()).to.equal(12.345);
+    });
+
+    it('should convert from decimal when using less than maximum decimal digits', function () {
+        var euro = Money.fromDecimal(123, 'EUR');
+        var forint = Money.fromDecimal(123.4, 'HUF');
+        var dinar = Money.fromDecimal(12.3, 'BHD');
+
+        expect(euro.amount).to.equal(12300);
+        expect(forint.amount).to.equal(12340);
+        expect(dinar.amount).to.equal(12300);
+    });
 });


### PR DESCRIPTION
A project I am working on uses JS-Money on the front and [PHP-Money](https://github.com/moneyphp/money) in the back. An unbelievable number popped up once when we let them work together on the HUF currency. 

PHP-Money uses [2 decimal digits](https://github.com/moneyphp/money/blob/master/resources/currency.php#L591) for HUF, where JS-Money uses 0.

A Hungarian colleague told me 0 decimal digits would be most logical, due to the smallest unit [Fillér](https://en.wikipedia.org/wiki/Fill%C3%A9r) not being made anymore. 

Although 0 is the a logical choice, following the currency standard is a better choice, which uses 2 decimal digits for HUF currency. An awesome side effect is that it allows [PHP-Money](https://github.com/moneyphp/money) and JS-Money to be used in unison!

## Changes
This PR updates the decimal digits with the most recent version; ISO 4217:2015. If this PR is accepted, all used currencies are up-to-date ✨. 

- [X] **AFN**: 0 -> 2
- [X] **ALL**: 0 -> 2
- [X] **AMD**: 0 -> 2
- [X] **COP**: 0 -> 2
- [X] **CRC**: 0 -> 2
- [X] **HUF**: 0 -> 2
- [X] **IDR**: 0 -> 2
- [X] **IQD**: 0 -> 3
- [X] **IRR**: 0 -> 2
- [X] **LAK**: 0 -> 2
- [X] **LBP**: 0 -> 2
- [X] **MGA**: 0 -> 2
- [X] **MMK**: 0 -> 2
- [X] **MUR**: 0 -> 2
- [X] **PKR**: 0 -> 2
- [X] **SOS**: 0 -> 2
- [X] **SYP**: 0 -> 2
- [X] **TZS**: 0 -> 2
- [X] **UZS**: 0 -> 2
- [X] **YER**: 0 -> 2

## Source
[ISO 4217](http://www.iso.org/iso/home/standards/currency_codes.htm) is the International Standard for currency codes.

