### PR TITLE
Add default rounder to fromDecimal

### DIFF
--- a/lib/money.js
+++ b/lib/money.js
@@ -105,6 +105,8 @@ Money.fromDecimal = function (amount, currency, rounder) {
         if (decimals > currency.decimal_digits)
             throw new Error("The currency " + currency.code + " supports only "
                 + currency.decimal_digits + " decimal digits");
+
+        rounder = Math.round;
     } else {
         if (['round', 'floor', 'ceil'].indexOf(rounder) === -1 && typeof rounder !== 'function')
             throw new TypeError('Invalid parameter rounder');
@@ -116,8 +118,7 @@ Money.fromDecimal = function (amount, currency, rounder) {
     var precisionMultiplier = Math.pow(10, currency.decimal_digits);
     var resultAmount = amount * precisionMultiplier;
 
-    if (rounder)
-        resultAmount = rounder(resultAmount);
+    resultAmount = rounder(resultAmount);
 
     return new Money(resultAmount, currency);
 };

--- a/test/money.test.js
+++ b/test/money.test.js
@@ -37,9 +37,13 @@ describe('Money', function () {
     it('should create a new instance from decimal string using `.fromDecimal()`', function () {
         var money = Money.fromDecimal('10.01', Money.EUR);
         var money1 = Money.fromDecimal('10', Money.EUR);
+        var money3 = Money.fromDecimal(16.90, Money.EUR);
+        var money4 = Money.fromDecimal(16.95, Money.EUR);
 
         expect(money.amount).to.equal(1001);
         expect(money1.amount).to.equal(1000);
+        expect(money3.amount).to.equal(1690);
+        expect(money4.amount).to.equal(1695);
     });
 
     it('should not create a new instance from decimal using `.fromDecimal()` if too many decimal places', function () {


### PR DESCRIPTION
If no rounder function is passed the rounder is set to `Math.round`. Tests that were added were recommended by @dnfrolov 