### PR TITLE
Added ISO-4217 numeric codes for currencies

### DIFF
--- a/lib/currency.js
+++ b/lib/currency.js
@@ -15,7 +15,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "USD",
-        "name_plural": "US dollars"
+        "name_plural": "US dollars",
+        "numericCode": "840"
     },
     "CAD": {
         "symbol": "CA$",
@@ -24,7 +25,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "CAD",
-        "name_plural": "Canadian dollars"
+        "name_plural": "Canadian dollars",
+        "numericCode": "124"
     },
     "EUR": {
         "symbol": "€",
@@ -33,7 +35,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "EUR",
-        "name_plural": "euros"
+        "name_plural": "euros",
+        "numericCode": "978"
     },
     "BTC": {
         "symbol": "BTC",
@@ -51,7 +54,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "AED",
-        "name_plural": "UAE dirhams"
+        "name_plural": "UAE dirhams",
+        "numericCode": "784"
     },
     "AFN": {
         "symbol": "Af",
@@ -60,7 +64,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "AFN",
-        "name_plural": "Afghan Afghanis"
+        "name_plural": "Afghan Afghanis",
+        "numericCode": "971"
     },
     "ALL": {
         "symbol": "ALL",
@@ -69,7 +74,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "ALL",
-        "name_plural": "Albanian lekë"
+        "name_plural": "Albanian lekë",
+        "numericCode": "008"
     },
     "AMD": {
         "symbol": "AMD",
@@ -78,7 +84,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "AMD",
-        "name_plural": "Armenian drams"
+        "name_plural": "Armenian drams",
+        "numericCode": "051"
     },
     "ARS": {
         "symbol": "AR$",
@@ -87,7 +94,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "ARS",
-        "name_plural": "Argentine pesos"
+        "name_plural": "Argentine pesos",
+        "numericCode": "032"
     },
     "AUD": {
         "symbol": "AU$",
@@ -96,7 +104,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "AUD",
-        "name_plural": "Australian dollars"
+        "name_plural": "Australian dollars",
+        "numericCode": "036"
     },
     "AZN": {
         "symbol": "man.",
@@ -105,7 +114,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "AZN",
-        "name_plural": "Azerbaijani manats"
+        "name_plural": "Azerbaijani manats",
+        "numericCode": "944"
     },
     "BAM": {
         "symbol": "KM",
@@ -114,7 +124,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "BAM",
-        "name_plural": "Bosnia-Herzegovina convertible marks"
+        "name_plural": "Bosnia-Herzegovina convertible marks",
+        "numericCode": "977"
     },
     "BDT": {
         "symbol": "Tk",
@@ -123,7 +134,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "BDT",
-        "name_plural": "Bangladeshi takas"
+        "name_plural": "Bangladeshi takas",
+        "numericCode": "050"
     },
     "BGN": {
         "symbol": "BGN",
@@ -132,7 +144,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "BGN",
-        "name_plural": "Bulgarian leva"
+        "name_plural": "Bulgarian leva",
+        "numericCode": "975"
     },
     "BHD": {
         "symbol": "BD",
@@ -141,7 +154,8 @@ var currencies = {
         "decimal_digits": 3,
         "rounding": 0,
         "code": "BHD",
-        "name_plural": "Bahraini dinars"
+        "name_plural": "Bahraini dinars",
+        "numericCode": "048"
     },
     "BIF": {
         "symbol": "FBu",
@@ -150,7 +164,8 @@ var currencies = {
         "decimal_digits": 0,
         "rounding": 0,
         "code": "BIF",
-        "name_plural": "Burundian francs"
+        "name_plural": "Burundian francs",
+        "numericCode": "108"
     },
     "BND": {
         "symbol": "BN$",
@@ -159,7 +174,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "BND",
-        "name_plural": "Brunei dollars"
+        "name_plural": "Brunei dollars",
+        "numericCode": "096"
     },
     "BOB": {
         "symbol": "Bs",
@@ -168,7 +184,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "BOB",
-        "name_plural": "Bolivian bolivianos"
+        "name_plural": "Bolivian bolivianos",
+        "numericCode": "068"
     },
     "BRL": {
         "symbol": "R$",
@@ -177,7 +194,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "BRL",
-        "name_plural": "Brazilian reals"
+        "name_plural": "Brazilian reals",
+        "numericCode": "986"
     },
     "BWP": {
         "symbol": "BWP",
@@ -186,16 +204,18 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "BWP",
-        "name_plural": "Botswanan pulas"
+        "name_plural": "Botswanan pulas",
+        "numericCode": "072"
     },
-    "BYR": {
-        "symbol": "BYR",
+    "BYN": {
+        "symbol": "BR",
         "name": "Belarusian Ruble",
-        "symbol_native": "BYR",
-        "decimal_digits": 0,
+        "symbol_native": "BR",
+        "decimal_digits": 2,
         "rounding": 0,
-        "code": "BYR",
-        "name_plural": "Belarusian rubles"
+        "code": "BYN",
+        "name_plural": "Belarusian rubles",
+        "numericCode": "933"
     },
     "BZD": {
         "symbol": "BZ$",
@@ -204,7 +224,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "BZD",
-        "name_plural": "Belize dollars"
+        "name_plural": "Belize dollars",
+        "numericCode": "084"
     },
     "CDF": {
         "symbol": "CDF",
@@ -213,7 +234,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "CDF",
-        "name_plural": "Congolese francs"
+        "name_plural": "Congolese francs",
+        "numericCode": "976"
     },
     "CHF": {
         "symbol": "CHF",
@@ -222,7 +244,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0.05,
         "code": "CHF",
-        "name_plural": "Swiss francs"
+        "name_plural": "Swiss francs",
+        "numericCode": "756"
     },
     "CLP": {
         "symbol": "CL$",
@@ -231,7 +254,8 @@ var currencies = {
         "decimal_digits": 0,
         "rounding": 0,
         "code": "CLP",
-        "name_plural": "Chilean pesos"
+        "name_plural": "Chilean pesos",
+        "numericCode": "152"
     },
     "CNY": {
         "symbol": "CN¥",
@@ -240,7 +264,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "CNY",
-        "name_plural": "Chinese yuan"
+        "name_plural": "Chinese yuan",
+        "numericCode": "156"
     },
     "COP": {
         "symbol": "CO$",
@@ -249,7 +274,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "COP",
-        "name_plural": "Colombian pesos"
+        "name_plural": "Colombian pesos",
+        "numericCode": "170"
     },
     "CRC": {
         "symbol": "₡",
@@ -258,7 +284,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "CRC",
-        "name_plural": "Costa Rican colóns"
+        "name_plural": "Costa Rican colóns",
+        "numericCode": "188"
     },
     "CVE": {
         "symbol": "CV$",
@@ -267,7 +294,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "CVE",
-        "name_plural": "Cape Verdean escudos"
+        "name_plural": "Cape Verdean escudos",
+        "numericCode": "132"
     },
     "CZK": {
         "symbol": "Kč",
@@ -276,7 +304,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "CZK",
-        "name_plural": "Czech Republic korunas"
+        "name_plural": "Czech Republic korunas",
+        "numericCode": "203"
     },
     "DJF": {
         "symbol": "Fdj",
@@ -285,7 +314,8 @@ var currencies = {
         "decimal_digits": 0,
         "rounding": 0,
         "code": "DJF",
-        "name_plural": "Djiboutian francs"
+        "name_plural": "Djiboutian francs",
+        "numericCode": "262"
     },
     "DKK": {
         "symbol": "Dkr",
@@ -294,7 +324,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "DKK",
-        "name_plural": "Danish kroner"
+        "name_plural": "Danish kroner",
+        "numericCode": "208"
     },
     "DOP": {
         "symbol": "RD$",
@@ -303,7 +334,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "DOP",
-        "name_plural": "Dominican pesos"
+        "name_plural": "Dominican pesos",
+        "numericCode": "214"
     },
     "DZD": {
         "symbol": "DA",
@@ -312,16 +344,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "DZD",
-        "name_plural": "Algerian dinars"
-    },
-    "EEK": {
-        "symbol": "Ekr",
-        "name": "Estonian Kroon",
-        "symbol_native": "kr",
-        "decimal_digits": 2,
-        "rounding": 0,
-        "code": "EEK",
-        "name_plural": "Estonian kroons"
+        "name_plural": "Algerian dinars",
+        "numericCode": "012"
     },
     "EGP": {
         "symbol": "EGP",
@@ -330,7 +354,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "EGP",
-        "name_plural": "Egyptian pounds"
+        "name_plural": "Egyptian pounds",
+        "numericCode": "818"
     },
     "ERN": {
         "symbol": "Nfk",
@@ -339,7 +364,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "ERN",
-        "name_plural": "Eritrean nakfas"
+        "name_plural": "Eritrean nakfas",
+        "numericCode": "232"
     },
     "ETB": {
         "symbol": "Br",
@@ -348,7 +374,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "ETB",
-        "name_plural": "Ethiopian birrs"
+        "name_plural": "Ethiopian birrs",
+        "numericCode": "230"
     },
     "GBP": {
         "symbol": "£",
@@ -357,7 +384,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "GBP",
-        "name_plural": "British pounds sterling"
+        "name_plural": "British pounds sterling",
+        "numericCode": "826"
     },
     "GEL": {
         "symbol": "GEL",
@@ -366,7 +394,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "GEL",
-        "name_plural": "Georgian laris"
+        "name_plural": "Georgian laris",
+        "numericCode": "981"
     },
     "GHS": {
         "symbol": "GH₵",
@@ -375,7 +404,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "GHS",
-        "name_plural": "Ghanaian cedis"
+        "name_plural": "Ghanaian cedis",
+        "numericCode": "936"
     },
     "GNF": {
         "symbol": "FG",
@@ -384,7 +414,8 @@ var currencies = {
         "decimal_digits": 0,
         "rounding": 0,
         "code": "GNF",
-        "name_plural": "Guinean francs"
+        "name_plural": "Guinean francs",
+        "numericCode": "324"
     },
     "GTQ": {
         "symbol": "GTQ",
@@ -393,7 +424,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "GTQ",
-        "name_plural": "Guatemalan quetzals"
+        "name_plural": "Guatemalan quetzals",
+        "numericCode": "320"
     },
     "HKD": {
         "symbol": "HK$",
@@ -402,7 +434,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "HKD",
-        "name_plural": "Hong Kong dollars"
+        "name_plural": "Hong Kong dollars",
+        "numericCode": "344"
     },
     "HNL": {
         "symbol": "HNL",
@@ -411,7 +444,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "HNL",
-        "name_plural": "Honduran lempiras"
+        "name_plural": "Honduran lempiras",
+        "numericCode": "340"
     },
     "HRK": {
         "symbol": "kn",
@@ -420,7 +454,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "HRK",
-        "name_plural": "Croatian kunas"
+        "name_plural": "Croatian kunas",
+        "numericCode": "191"
     },
     "HUF": {
         "symbol": "Ft",
@@ -429,7 +464,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "HUF",
-        "name_plural": "Hungarian forints"
+        "name_plural": "Hungarian forints",
+        "numericCode": "348"
     },
     "IDR": {
         "symbol": "Rp",
@@ -438,7 +474,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "IDR",
-        "name_plural": "Indonesian rupiahs"
+        "name_plural": "Indonesian rupiahs",
+        "numericCode": "360"
     },
     "ILS": {
         "symbol": "₪",
@@ -447,7 +484,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "ILS",
-        "name_plural": "Israeli new sheqels"
+        "name_plural": "Israeli new sheqels",
+        "numericCode": "376"
     },
     "INR": {
         "symbol": "Rs",
@@ -456,7 +494,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "INR",
-        "name_plural": "Indian rupees"
+        "name_plural": "Indian rupees",
+        "numericCode": "356"
     },
     "IQD": {
         "symbol": "IQD",
@@ -465,7 +504,8 @@ var currencies = {
         "decimal_digits": 3,
         "rounding": 0,
         "code": "IQD",
-        "name_plural": "Iraqi dinars"
+        "name_plural": "Iraqi dinars",
+        "numericCode": "368"
     },
     "IRR": {
         "symbol": "IRR",
@@ -474,7 +514,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "IRR",
-        "name_plural": "Iranian rials"
+        "name_plural": "Iranian rials",
+        "numericCode": "364"
     },
     "ISK": {
         "symbol": "Ikr",
@@ -483,7 +524,8 @@ var currencies = {
         "decimal_digits": 0,
         "rounding": 0,
         "code": "ISK",
-        "name_plural": "Icelandic krónur"
+        "name_plural": "Icelandic krónur",
+        "numericCode": "352"
     },
     "JMD": {
         "symbol": "J$",
@@ -492,7 +534,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "JMD",
-        "name_plural": "Jamaican dollars"
+        "name_plural": "Jamaican dollars",
+        "numericCode": "388"
     },
     "JOD": {
         "symbol": "JD",
@@ -501,7 +544,8 @@ var currencies = {
         "decimal_digits": 3,
         "rounding": 0,
         "code": "JOD",
-        "name_plural": "Jordanian dinars"
+        "name_plural": "Jordanian dinars",
+        "numericCode": "400"
     },
     "JPY": {
         "symbol": "¥",
@@ -510,7 +554,8 @@ var currencies = {
         "decimal_digits": 0,
         "rounding": 0,
         "code": "JPY",
-        "name_plural": "Japanese yen"
+        "name_plural": "Japanese yen",
+        "numericCode": "392"
     },
     "KES": {
         "symbol": "Ksh",
@@ -519,7 +564,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "KES",
-        "name_plural": "Kenyan shillings"
+        "name_plural": "Kenyan shillings",
+        "numericCode": "404"
     },
     "KHR": {
         "symbol": "KHR",
@@ -528,7 +574,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "KHR",
-        "name_plural": "Cambodian riels"
+        "name_plural": "Cambodian riels",
+        "numericCode": "116"
     },
     "KMF": {
         "symbol": "CF",
@@ -537,7 +584,8 @@ var currencies = {
         "decimal_digits": 0,
         "rounding": 0,
         "code": "KMF",
-        "name_plural": "Comorian francs"
+        "name_plural": "Comorian francs",
+        "numericCode": "174"
     },
     "KRW": {
         "symbol": "₩",
@@ -546,7 +594,8 @@ var currencies = {
         "decimal_digits": 0,
         "rounding": 0,
         "code": "KRW",
-        "name_plural": "South Korean won"
+        "name_plural": "South Korean won",
+        "numericCode": "410"
     },
     "KWD": {
         "symbol": "KD",
@@ -555,16 +604,18 @@ var currencies = {
         "decimal_digits": 3,
         "rounding": 0,
         "code": "KWD",
-        "name_plural": "Kuwaiti dinars"
+        "name_plural": "Kuwaiti dinars",
+        "numericCode": "414"
     },
     "KZT": {
-        "symbol": "KZT",
+        "symbol": "₸",
         "name": "Kazakhstani Tenge",
-        "symbol_native": "тңг.",
+        "symbol_native": "₸",
         "decimal_digits": 2,
         "rounding": 0,
         "code": "KZT",
-        "name_plural": "Kazakhstani tenges"
+        "name_plural": "Kazakhstani tenges",
+        "numericCode": "398"
     },
     "LAK": {
         "symbol": "₭",
@@ -573,7 +624,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "LAK",
-        "name_plural": "Lao kips"
+        "name_plural": "Lao kips",
+        "numericCode": "418"
     },
     "LBP": {
         "symbol": "LB£",
@@ -582,7 +634,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "LBP",
-        "name_plural": "Lebanese pounds"
+        "name_plural": "Lebanese pounds",
+        "numericCode": "422"
     },
     "LKR": {
         "symbol": "SLRs",
@@ -591,25 +644,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "LKR",
-        "name_plural": "Sri Lankan rupees"
-    },
-    "LTL": {
-        "symbol": "Lt",
-        "name": "Lithuanian Litas",
-        "symbol_native": "Lt",
-        "decimal_digits": 2,
-        "rounding": 0,
-        "code": "LTL",
-        "name_plural": "Lithuanian litai"
-    },
-    "LVL": {
-        "symbol": "Ls",
-        "name": "Latvian Lats",
-        "symbol_native": "Ls",
-        "decimal_digits": 2,
-        "rounding": 0,
-        "code": "LVL",
-        "name_plural": "Latvian lati"
+        "name_plural": "Sri Lankan rupees",
+        "numericCode": "144"
     },
     "LYD": {
         "symbol": "LD",
@@ -618,7 +654,8 @@ var currencies = {
         "decimal_digits": 3,
         "rounding": 0,
         "code": "LYD",
-        "name_plural": "Libyan dinars"
+        "name_plural": "Libyan dinars",
+        "numericCode": "434"
     },
     "MAD": {
         "symbol": "MAD",
@@ -627,7 +664,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "MAD",
-        "name_plural": "Moroccan dirhams"
+        "name_plural": "Moroccan dirhams",
+        "numericCode": "504"
     },
     "MDL": {
         "symbol": "MDL",
@@ -636,7 +674,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "MDL",
-        "name_plural": "Moldovan lei"
+        "name_plural": "Moldovan lei",
+        "numericCode": "498"
     },
     "MGA": {
         "symbol": "MGA",
@@ -645,7 +684,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "MGA",
-        "name_plural": "Malagasy Ariaries"
+        "name_plural": "Malagasy Ariaries",
+        "numericCode": "969"
     },
     "MKD": {
         "symbol": "MKD",
@@ -654,7 +694,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "MKD",
-        "name_plural": "Macedonian denari"
+        "name_plural": "Macedonian denari",
+        "numericCode": "807"
     },
     "MMK": {
         "symbol": "MMK",
@@ -663,7 +704,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "MMK",
-        "name_plural": "Myanma kyats"
+        "name_plural": "Myanma kyats",
+        "numericCode": "104"
     },
     "MOP": {
         "symbol": "MOP$",
@@ -672,7 +714,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "MOP",
-        "name_plural": "Macanese patacas"
+        "name_plural": "Macanese patacas",
+        "numericCode": "446"
     },
     "MUR": {
         "symbol": "MURs",
@@ -681,7 +724,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "MUR",
-        "name_plural": "Mauritian rupees"
+        "name_plural": "Mauritian rupees",
+        "numericCode": "480"
     },
     "MXN": {
         "symbol": "MX$",
@@ -690,7 +734,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "MXN",
-        "name_plural": "Mexican pesos"
+        "name_plural": "Mexican pesos",
+        "numericCode": "484"
     },
     "MYR": {
         "symbol": "RM",
@@ -699,7 +744,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "MYR",
-        "name_plural": "Malaysian ringgits"
+        "name_plural": "Malaysian ringgits",
+        "numericCode": "458"
     },
     "MZN": {
         "symbol": "MTn",
@@ -708,7 +754,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "MZN",
-        "name_plural": "Mozambican meticals"
+        "name_plural": "Mozambican meticals",
+        "numericCode": "943"
     },
     "NAD": {
         "symbol": "N$",
@@ -717,7 +764,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "NAD",
-        "name_plural": "Namibian dollars"
+        "name_plural": "Namibian dollars",
+        "numericCode": "516"
     },
     "NGN": {
         "symbol": "₦",
@@ -726,7 +774,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "NGN",
-        "name_plural": "Nigerian nairas"
+        "name_plural": "Nigerian nairas",
+        "numericCode": "566"
     },
     "NIO": {
         "symbol": "C$",
@@ -735,7 +784,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "NIO",
-        "name_plural": "Nicaraguan córdobas"
+        "name_plural": "Nicaraguan córdobas",
+        "numericCode": "558"
     },
     "NOK": {
         "symbol": "Nkr",
@@ -744,7 +794,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "NOK",
-        "name_plural": "Norwegian kroner"
+        "name_plural": "Norwegian kroner",
+        "numericCode": "578"
     },
     "NPR": {
         "symbol": "NPRs",
@@ -753,7 +804,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "NPR",
-        "name_plural": "Nepalese rupees"
+        "name_plural": "Nepalese rupees",
+        "numericCode": "524"
     },
     "NZD": {
         "symbol": "NZ$",
@@ -762,7 +814,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "NZD",
-        "name_plural": "New Zealand dollars"
+        "name_plural": "New Zealand dollars",
+        "numericCode": "554"
     },
     "OMR": {
         "symbol": "OMR",
@@ -771,7 +824,8 @@ var currencies = {
         "decimal_digits": 3,
         "rounding": 0,
         "code": "OMR",
-        "name_plural": "Omani rials"
+        "name_plural": "Omani rials",
+        "numericCode": "512"
     },
     "PAB": {
         "symbol": "B/.",
@@ -780,7 +834,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "PAB",
-        "name_plural": "Panamanian balboas"
+        "name_plural": "Panamanian balboas",
+        "numericCode": "590"
     },
     "PEN": {
         "symbol": "S/.",
@@ -789,7 +844,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "PEN",
-        "name_plural": "Peruvian nuevos soles"
+        "name_plural": "Peruvian nuevos soles",
+        "numericCode": "604"
     },
     "PHP": {
         "symbol": "₱",
@@ -798,7 +854,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "PHP",
-        "name_plural": "Philippine pesos"
+        "name_plural": "Philippine pesos",
+        "numericCode": "608"
     },
     "PKR": {
         "symbol": "PKRs",
@@ -807,7 +864,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "PKR",
-        "name_plural": "Pakistani rupees"
+        "name_plural": "Pakistani rupees",
+        "numericCode": "586"
     },
     "PLN": {
         "symbol": "zł",
@@ -816,7 +874,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "PLN",
-        "name_plural": "Polish zlotys"
+        "name_plural": "Polish zlotys",
+        "numericCode": "985"
     },
     "PYG": {
         "symbol": "₲",
@@ -825,7 +884,8 @@ var currencies = {
         "decimal_digits": 0,
         "rounding": 0,
         "code": "PYG",
-        "name_plural": "Paraguayan guaranis"
+        "name_plural": "Paraguayan guaranis",
+        "numericCode": "600"
     },
     "QAR": {
         "symbol": "QR",
@@ -834,7 +894,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "QAR",
-        "name_plural": "Qatari rials"
+        "name_plural": "Qatari rials",
+        "numericCode": "634"
     },
     "RON": {
         "symbol": "RON",
@@ -843,7 +904,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "RON",
-        "name_plural": "Romanian lei"
+        "name_plural": "Romanian lei",
+        "numericCode": "946"
     },
     "RSD": {
         "symbol": "din.",
@@ -852,7 +914,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "RSD",
-        "name_plural": "Serbian dinars"
+        "name_plural": "Serbian dinars",
+        "numericCode": "941"
     },
     "RUB": {
         "symbol": "RUB",
@@ -861,7 +924,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "RUB",
-        "name_plural": "Russian rubles"
+        "name_plural": "Russian rubles",
+        "numericCode": "643"
     },
     "RWF": {
         "symbol": "RWF",
@@ -870,7 +934,8 @@ var currencies = {
         "decimal_digits": 0,
         "rounding": 0,
         "code": "RWF",
-        "name_plural": "Rwandan francs"
+        "name_plural": "Rwandan francs",
+        "numericCode": "646"
     },
     "SAR": {
         "symbol": "SR",
@@ -879,7 +944,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "SAR",
-        "name_plural": "Saudi riyals"
+        "name_plural": "Saudi riyals",
+        "numericCode": "682"
     },
     "SDG": {
         "symbol": "SDG",
@@ -888,7 +954,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "SDG",
-        "name_plural": "Sudanese pounds"
+        "name_plural": "Sudanese pounds",
+        "numericCode": "938"
     },
     "SEK": {
         "symbol": "Skr",
@@ -897,7 +964,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "SEK",
-        "name_plural": "Swedish kronor"
+        "name_plural": "Swedish kronor",
+        "numericCode": "752"
     },
     "SGD": {
         "symbol": "S$",
@@ -906,7 +974,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "SGD",
-        "name_plural": "Singapore dollars"
+        "name_plural": "Singapore dollars",
+        "numericCode": "702"
     },
     "SOS": {
         "symbol": "Ssh",
@@ -915,7 +984,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "SOS",
-        "name_plural": "Somali shillings"
+        "name_plural": "Somali shillings",
+        "numericCode": "706"
     },
     "SYP": {
         "symbol": "SY£",
@@ -924,7 +994,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "SYP",
-        "name_plural": "Syrian pounds"
+        "name_plural": "Syrian pounds",
+        "numericCode": "760"
     },
     "THB": {
         "symbol": "฿",
@@ -933,7 +1004,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "THB",
-        "name_plural": "Thai baht"
+        "name_plural": "Thai baht",
+        "numericCode": "764"
     },
     "TND": {
         "symbol": "DT",
@@ -942,7 +1014,8 @@ var currencies = {
         "decimal_digits": 3,
         "rounding": 0,
         "code": "TND",
-        "name_plural": "Tunisian dinars"
+        "name_plural": "Tunisian dinars",
+        "numericCode": "788"
     },
     "TOP": {
         "symbol": "T$",
@@ -951,7 +1024,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "TOP",
-        "name_plural": "Tongan paʻanga"
+        "name_plural": "Tongan paʻanga",
+        "numericCode": "776"
     },
     "TRY": {
         "symbol": "TL",
@@ -960,7 +1034,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "TRY",
-        "name_plural": "Turkish Lira"
+        "name_plural": "Turkish Lira",
+        "numericCode": "949"
     },
     "TTD": {
         "symbol": "TT$",
@@ -969,7 +1044,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "TTD",
-        "name_plural": "Trinidad and Tobago dollars"
+        "name_plural": "Trinidad and Tobago dollars",
+        "numericCode": "780"
     },
     "TWD": {
         "symbol": "NT$",
@@ -978,7 +1054,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "TWD",
-        "name_plural": "New Taiwan dollars"
+        "name_plural": "New Taiwan dollars",
+        "numericCode": "901"
     },
     "TZS": {
         "symbol": "TSh",
@@ -987,7 +1064,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "TZS",
-        "name_plural": "Tanzanian shillings"
+        "name_plural": "Tanzanian shillings",
+        "numericCode": "834"
     },
     "UAH": {
         "symbol": "₴",
@@ -996,7 +1074,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "UAH",
-        "name_plural": "Ukrainian hryvnias"
+        "name_plural": "Ukrainian hryvnias",
+        "numericCode": "980"
     },
     "UGX": {
         "symbol": "USh",
@@ -1005,7 +1084,8 @@ var currencies = {
         "decimal_digits": 0,
         "rounding": 0,
         "code": "UGX",
-        "name_plural": "Ugandan shillings"
+        "name_plural": "Ugandan shillings",
+        "numericCode": "800"
     },
     "UYU": {
         "symbol": "$U",
@@ -1014,7 +1094,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "UYU",
-        "name_plural": "Uruguayan pesos"
+        "name_plural": "Uruguayan pesos",
+        "numericCode": "858"
     },
     "UZS": {
         "symbol": "UZS",
@@ -1023,7 +1104,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "UZS",
-        "name_plural": "Uzbekistan som"
+        "name_plural": "Uzbekistan som",
+        "numericCode": "860"
     },
     "VEF": {
         "symbol": "Bs.F.",
@@ -1032,7 +1114,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "VEF",
-        "name_plural": "Venezuelan bolívars"
+        "name_plural": "Venezuelan bolívars",
+        "numericCode": "937"
     },
     "VND": {
         "symbol": "₫",
@@ -1041,7 +1124,8 @@ var currencies = {
         "decimal_digits": 0,
         "rounding": 0,
         "code": "VND",
-        "name_plural": "Vietnamese dong"
+        "name_plural": "Vietnamese dong",
+        "numericCode": "704"
     },
     "XAF": {
         "symbol": "FCFA",
@@ -1050,7 +1134,8 @@ var currencies = {
         "decimal_digits": 0,
         "rounding": 0,
         "code": "XAF",
-        "name_plural": "CFA francs BEAC"
+        "name_plural": "CFA francs BEAC",
+        "numericCode": "950"
     },
     "XOF": {
         "symbol": "CFA",
@@ -1059,7 +1144,8 @@ var currencies = {
         "decimal_digits": 0,
         "rounding": 0,
         "code": "XOF",
-        "name_plural": "CFA francs BCEAO"
+        "name_plural": "CFA francs BCEAO",
+        "numericCode": "952"
     },
     "YER": {
         "symbol": "YR",
@@ -1068,7 +1154,8 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "YER",
-        "name_plural": "Yemeni rials"
+        "name_plural": "Yemeni rials",
+        "numericCode": "886"
     },
     "ZAR": {
         "symbol": "R",
@@ -1077,19 +1164,21 @@ var currencies = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "ZAR",
-        "name_plural": "South African rand"
+        "name_plural": "South African rand",
+        "numericCode": "710"
     },
-    "ZMK": {
+    "ZMW": {
         "symbol": "ZK",
         "name": "Zambian Kwacha",
         "symbol_native": "ZK",
-        "decimal_digits": 0,
+        "decimal_digits": 2,
         "rounding": 0,
-        "code": "ZMK",
-        "name_plural": "Zambian kwachas"
+        "code": "ZMW",
+        "name_plural": "Zambian kwachas",
+        "numericCode": "967"
     }
 };
 
 Object.keys(currencies).forEach(function (currency) {
-   module.exports[currency] = currencies[currency]; 
+    module.exports[currency] = currencies[currency];
 });

--- a/test/money.test.js
+++ b/test/money.test.js
@@ -342,4 +342,38 @@ describe('Money', function () {
 
         expect(minBitcoin.toDecimal()).to.equal(0.00000001)
     });
+
+    it('should return correct numeric code for currency', function () {
+        var eur = Money.EUR;
+        var usd = Money.USD;
+        var belarusRuble = Money.BYN;
+        var kzTenge = Money.KZT;
+
+        expect(eur.numericCode).to.equal('978');
+        expect(usd.numericCode).to.equal('840');
+        expect(belarusRuble.numericCode).to.equal('933');
+        expect(kzTenge.numericCode).to.equal('398');
+    });
+
+    it('changed currencies BYR, ZMK should return correctly', function () {
+        var changedCurrencies = {
+            BYR: 'BYN',
+            ZMK: 'ZMW'
+        }
+
+        expect(Money).to.not.have.property('BYR');
+        expect(Money).to.not.have.property('ZMK');
+        expect(Money[changedCurrencies['BYR']]).to.not.be.empty;
+        expect(Money[changedCurrencies['BYR']]).to.have.property('code').equal(changedCurrencies['BYR']);
+        expect(Money[changedCurrencies['ZMK']]).to.not.be.empty;
+        expect(Money[changedCurrencies['ZMK']]).to.have.property('code').equal(changedCurrencies['ZMK']);
+    });
+
+    it('out of circulation currencies EEK, LVL, LTL should not exist', function () {
+        var unusedCurrencies=['EEK', 'LVL', 'LTL'];
+
+        expect(Money).to.not.have.property(unusedCurrencies[0]);
+        expect(Money).to.not.have.property(unusedCurrencies[1]);
+        expect(Money).to.not.have.property(unusedCurrencies[2]);
+    });
 });


### PR DESCRIPTION
Removed out of circulation currencies (EEK,LTL,LVL)
Changed currency codes (BYR to BYN, ZMK to ZMW)

Numeric codes are taken from https://www.currency-iso.org/en/home/tables/table-a1.html
Changed decimal_digits for currencies BYR and ZMK from 0 to 2
Removed former currencies of Estonia (EEK) , Latvia (LVL) and Lithuania (LTL) , as they are now replaced by EUR
Added KZT symbol "₸"

Added tests for currency codes , removed currencies and changed currencies